### PR TITLE
Fix escaping in wiktionary definitions

### DIFF
--- a/dal.py
+++ b/dal.py
@@ -145,7 +145,7 @@ def make_wiktionary_section(month, day):
 
     definitions_stripped = []
     for li in soup.findAll('li'):
-        definitions_stripped.append(strip_html(li.renderContents()))
+        definitions_stripped.append(unescape(strip_html(li.renderContents()).decode('utf-8')))
     definitions = []
     if len(definitions_stripped) > 1:
         for i, t in enumerate(definitions_stripped):


### PR DESCRIPTION
There was a lot of '&#32;' in today's DAL post, this commit should fix that.